### PR TITLE
Add OTel metrics performance benchmarking infrastructure

### DIFF
--- a/.github/custom-tests/tyk-analytics-database/cluster.tf
+++ b/.github/custom-tests/tyk-analytics-database/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-analytics-database/deployments.tf
+++ b/.github/custom-tests/tyk-analytics-database/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = true
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = false
+open_telemetry_sampling_ratio          = "0"
+open_telemetry_metrics_enabled         = false
+open_telemetry_metrics_runtime_metrics = false
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-analytics-database/tests.tf
+++ b/.github/custom-tests/tyk-analytics-database/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-analytics-prometheus/cluster.tf
+++ b/.github/custom-tests/tyk-analytics-prometheus/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-analytics-prometheus/deployments.tf
+++ b/.github/custom-tests/tyk-analytics-prometheus/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = false
+analytics_prometheus_enabled  = true
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = false
+open_telemetry_sampling_ratio          = "0"
+open_telemetry_metrics_enabled         = false
+open_telemetry_metrics_runtime_metrics = false
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-analytics-prometheus/tests.tf
+++ b/.github/custom-tests/tyk-analytics-prometheus/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-otel-baseline/cluster.tf
+++ b/.github/custom-tests/tyk-otel-baseline/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-otel-baseline/deployments.tf
+++ b/.github/custom-tests/tyk-otel-baseline/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = false
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = false
+open_telemetry_sampling_ratio          = "0"
+open_telemetry_metrics_enabled         = false
+open_telemetry_metrics_runtime_metrics = false
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-otel-baseline/tests.tf
+++ b/.github/custom-tests/tyk-otel-baseline/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-otel-metrics-only/cluster.tf
+++ b/.github/custom-tests/tyk-otel-metrics-only/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-otel-metrics-only/deployments.tf
+++ b/.github/custom-tests/tyk-otel-metrics-only/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = false
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = true
+open_telemetry_sampling_ratio          = "0"
+open_telemetry_metrics_enabled         = true
+open_telemetry_metrics_runtime_metrics = false
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-otel-metrics-only/tests.tf
+++ b/.github/custom-tests/tyk-otel-metrics-only/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-otel-metrics-runtime/cluster.tf
+++ b/.github/custom-tests/tyk-otel-metrics-runtime/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-otel-metrics-runtime/deployments.tf
+++ b/.github/custom-tests/tyk-otel-metrics-runtime/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = false
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = true
+open_telemetry_sampling_ratio          = "0"
+open_telemetry_metrics_enabled         = true
+open_telemetry_metrics_runtime_metrics = true
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-otel-metrics-runtime/tests.tf
+++ b/.github/custom-tests/tyk-otel-metrics-runtime/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-otel-metrics-tracing-full/cluster.tf
+++ b/.github/custom-tests/tyk-otel-metrics-tracing-full/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-otel-metrics-tracing-full/deployments.tf
+++ b/.github/custom-tests/tyk-otel-metrics-tracing-full/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = false
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = true
+open_telemetry_sampling_ratio          = "1.0"
+open_telemetry_metrics_enabled         = true
+open_telemetry_metrics_runtime_metrics = true
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-otel-metrics-tracing-full/tests.tf
+++ b/.github/custom-tests/tyk-otel-metrics-tracing-full/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-otel-metrics-tracing/cluster.tf
+++ b/.github/custom-tests/tyk-otel-metrics-tracing/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-otel-metrics-tracing/deployments.tf
+++ b/.github/custom-tests/tyk-otel-metrics-tracing/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = false
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = true
+open_telemetry_sampling_ratio          = "0.5"
+open_telemetry_metrics_enabled         = true
+open_telemetry_metrics_runtime_metrics = true
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-otel-metrics-tracing/tests.tf
+++ b/.github/custom-tests/tyk-otel-metrics-tracing/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-otel-metrics-vs-analytics/cluster.tf
+++ b/.github/custom-tests/tyk-otel-metrics-vs-analytics/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-otel-metrics-vs-analytics/deployments.tf
+++ b/.github/custom-tests/tyk-otel-metrics-vs-analytics/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = true
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = true
+open_telemetry_sampling_ratio          = "0"
+open_telemetry_metrics_enabled         = true
+open_telemetry_metrics_runtime_metrics = false
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-otel-metrics-vs-analytics/tests.tf
+++ b/.github/custom-tests/tyk-otel-metrics-vs-analytics/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/custom-tests/tyk-otel-tracing-only/cluster.tf
+++ b/.github/custom-tests/tyk-otel-tracing-only/cluster.tf
@@ -1,0 +1,18 @@
+cluster_location          = "westus"
+cluster_machine_type      = "Standard_F8s_v2"
+service_machine_type      = ""
+upstream_machine_type     = ""
+tests_machine_type        = ""
+resources_machine_type    = ""
+dependencies_machine_type = ""
+
+services_nodes_count     = 1
+upstream_nodes_count     = 1
+tests_nodes_count        = 1
+resource_nodes_count     = 1
+dependencies_nodes_count = 2
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false

--- a/.github/custom-tests/tyk-otel-tracing-only/deployments.tf
+++ b/.github/custom-tests/tyk-otel-tracing-only/deployments.tf
@@ -1,0 +1,32 @@
+kubernetes_config_context = "performance-testing"
+
+analytics_database_enabled    = false
+analytics_prometheus_enabled  = false
+auth_enabled                  = false
+quota_enabled                 = false
+rate_limit_enabled            = false
+
+open_telemetry_enabled                 = true
+open_telemetry_sampling_ratio          = "0.5"
+open_telemetry_metrics_enabled         = false
+open_telemetry_metrics_runtime_metrics = false
+
+hpa_enabled             = false
+replica_count           = 4
+external_traffic_policy = "Local"
+resources_requests_cpu    = "0"
+resources_requests_memory = "0"
+resources_limits_cpu      = "0"
+resources_limits_memory   = "0"
+
+tyk_enabled         = true
+tyk_version         = "v5.8.0"
+tyk_deployment_type = "Deployment"
+tyk_go_gc           = 1600
+tyk_go_max_procs    = 8
+
+kong_enabled     = false
+gravitee_enabled = false
+traefik_enabled  = false
+
+grafana_service_type = "ClusterIP"

--- a/.github/custom-tests/tyk-otel-tracing-only/tests.tf
+++ b/.github/custom-tests/tyk-otel-tracing-only/tests.tf
@@ -1,0 +1,11 @@
+kubernetes_config_context = "performance-testing"
+
+tyk_enabled      = true
+kong_enabled     = false
+gravitee_enabled = false
+
+tests_executor       = "constant-vus"
+tests_duration       = 900
+tests_rate           = 20000
+tests_virtual_users  = 50
+tests_parallelism    = 1

--- a/.github/workflows/otel_metrics_benchmark.yml
+++ b/.github/workflows/otel_metrics_benchmark.yml
@@ -1,0 +1,342 @@
+name: OTel Metrics Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      tyk_version:
+        description: 'Tyk Gateway version'
+        required: false
+        type: string
+        default: 'v5.8.0'
+      cloud:
+        description: 'Choose Cloud Provider'
+        required: true
+        type: choice
+        default: Azure
+        options:
+          - Azure
+          - AWS
+          - GCP
+
+env:
+  provider: ${{ inputs.cloud == 'Azure' && 'aks' || (inputs.cloud == 'AWS' && 'eks' || 'gke') }}
+  CUSTOM_TESTS_DIR: .github/custom-tests
+
+concurrency:
+  group: otel-metrics-${{ inputs.cloud }}
+
+jobs:
+  benchmark:
+    name: "${{ matrix.config }} (${{ inputs.cloud }})"
+    needs: create-cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        config:
+          - tyk-otel-baseline
+          - tyk-otel-tracing-only
+          - tyk-otel-metrics-only
+          - tyk-otel-metrics-runtime
+          - tyk-otel-metrics-tracing
+          - tyk-otel-metrics-tracing-full
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Configure AKS credentials
+        if: ${{ inputs.cloud == 'Azure' }}
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Configure AWS credentials
+        if: ${{ inputs.cloud == 'AWS' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_CLUSTER_LOCATION }}
+
+      - name: Authenticate into gcloud
+        if: ${{ inputs.cloud == 'GCP' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Install gcloud CLI
+        if: ${{ inputs.cloud == 'GCP' }}
+        uses: google-github-actions/setup-gcloud@v2.1.0
+
+      - name: Install gcloud k8s auth component
+        if: ${{ inputs.cloud == 'GCP' }}
+        run: gcloud components install gke-gcloud-auth-plugin
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3.1.1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: "1.8.2"
+
+      - name: Create Terraform Cloud descriptors
+        run: |
+          cp ${{ env.provider }}/terraform.cloud.tf.example ${{ env.provider }}/terraform.cloud.tf
+          cp .github/${{ env.provider }}/deployments.tf deployments/terraform.cloud.tf
+          cp .github/${{ env.provider }}/tests.tf tests/terraform.cloud.tf
+
+      - name: Connect to AKS cluster
+        if: ${{ inputs.cloud == 'Azure' }}
+        run: |
+          az aks get-credentials \
+            --resource-group "pt-${{ vars.AZURE_CLUSTER_LOCATION }}" \
+            --name "pt-${{ vars.AZURE_CLUSTER_LOCATION }}"
+
+          kubectl config rename-context $(kubectl config current-context) performance-testing
+
+      - name: Connect to EKS cluster
+        if: ${{ inputs.cloud == 'AWS' }}
+        run: |
+          aws eks --region "${{ vars.AWS_CLUSTER_LOCATION }}" update-kubeconfig --name "pt-${{ vars.AWS_CLUSTER_LOCATION }}"
+
+          kubectl config rename-context $(kubectl config current-context) performance-testing
+
+      - name: Connect to GKE cluster
+        if: ${{ inputs.cloud == 'GCP' }}
+        run: |
+          gcloud container clusters get-credentials "pt-${{ vars.GCP_CLUSTER_LOCATION }}" \
+            --zone "${{ vars.GCP_CLUSTER_LOCATION }}" \
+            --project "${{ secrets.GCP_PROJECT }}"
+
+          kubectl config rename-context $(kubectl config current-context) performance-testing
+
+      - name: "[${{ matrix.config }}] Copy deployment config"
+        run: |
+          cp "${{ env.CUSTOM_TESTS_DIR }}/${{ matrix.config }}/deployments.tf" deployments/main.tfvars
+          cp "${{ env.CUSTOM_TESTS_DIR }}/${{ matrix.config }}/tests.tf" tests/main.tfvars
+
+      - name: "[${{ matrix.config }}] Override Tyk version"
+        if: ${{ inputs.tyk_version != 'v5.8.0' }}
+        run: |
+          sed -i 's/tyk_version.*=.*/tyk_version         = "${{ inputs.tyk_version }}"/' deployments/main.tfvars
+
+      - name: "[${{ matrix.config }}] Deploy"
+        run: |
+          cd deployments
+          terraform init
+          terraform apply \
+            --var="tyk_license=${{ secrets.DASH_LICENSE }}" \
+            --var-file=main.tfvars \
+            --var="kubernetes_config_context=performance-testing" \
+            --auto-approve
+          sleep 300
+
+      - name: "[${{ matrix.config }}] Run tests"
+        run: |
+          cd tests
+          terraform init
+          terraform apply \
+            --var-file=main.tfvars \
+            --var="kubernetes_config_context=performance-testing" \
+            --auto-approve
+
+      - name: "[${{ matrix.config }}] Capture Grafana snapshot"
+        run: |
+          kubectl logs -n dependencies $(kubectl get pods -n dependencies --selector=app=snapshot-job -o jsonpath='{.items[-1].metadata.name}') --tail=1
+
+      - name: "[${{ matrix.config }}] Destroy tests"
+        if: always()
+        run: |
+          cd tests
+          terraform init
+          terraform destroy \
+            --var="kubernetes_config_context=performance-testing" \
+            --var-file=main.tfvars \
+            --auto-approve
+
+      - name: "[${{ matrix.config }}] Destroy deployments"
+        if: always()
+        run: |
+          cd deployments
+          terraform destroy \
+            --var="kubernetes_config_context=performance-testing" \
+            --var="tyk_license=${{ secrets.DASH_LICENSE }}" \
+            --var-file=main.tfvars \
+            --auto-approve
+
+  create-cluster:
+    name: "Create ${{ inputs.cloud }} cluster"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Configure AKS credentials
+        if: ${{ inputs.cloud == 'Azure' }}
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Configure AWS credentials
+        if: ${{ inputs.cloud == 'AWS' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_CLUSTER_LOCATION }}
+
+      - name: Authenticate into gcloud
+        if: ${{ inputs.cloud == 'GCP' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Install gcloud CLI
+        if: ${{ inputs.cloud == 'GCP' }}
+        uses: google-github-actions/setup-gcloud@v2.1.0
+
+      - name: Install gcloud k8s auth component
+        if: ${{ inputs.cloud == 'GCP' }}
+        run: gcloud components install gke-gcloud-auth-plugin
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3.1.1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: "1.8.2"
+
+      - name: Create Terraform Cloud descriptors
+        run: cp ${{ env.provider }}/terraform.cloud.tf.example ${{ env.provider }}/terraform.cloud.tf
+
+      - name: Copy cluster config
+        run: cp "${{ env.CUSTOM_TESTS_DIR }}/tyk-otel-baseline/cluster.tf" ${{ env.provider }}/main.tfvars
+
+      - name: AKS cluster
+        if: ${{ inputs.cloud == 'Azure' }}
+        run: |
+          cd aks
+          terraform init
+          terraform apply \
+            --var="cluster_location=${{ vars.AZURE_CLUSTER_LOCATION }}" \
+            --var="cluster_machine_type=${{ vars.AZURE_CLUSTER_MACHINE_TYPE }}" \
+            --var="upstream_machine_type=${{ vars.AZURE_UPSTREAM_MACHINE_TYPE }}" \
+            --var="tests_machine_type=${{ vars.AZURE_TEST_MACHINE_TYPE }}" \
+            --var-file=main.tfvars \
+            --auto-approve
+
+      - name: EKS cluster
+        if: ${{ inputs.cloud == 'AWS' }}
+        run: |
+          cd eks
+          terraform init
+          terraform apply \
+            --var="cluster_location=${{ vars.AWS_CLUSTER_LOCATION }}" \
+            --var="cluster_machine_type=${{ vars.AWS_CLUSTER_MACHINE_TYPE }}" \
+            --var="upstream_machine_type=${{ vars.AWS_UPSTREAM_MACHINE_TYPE }}" \
+            --var="tests_machine_type=${{ vars.AWS_TEST_MACHINE_TYPE }}" \
+            --var-file=main.tfvars \
+            --auto-approve
+
+      - name: GKE cluster
+        if: ${{ inputs.cloud == 'GCP' }}
+        run: |
+          cd gke
+          terraform init
+          terraform apply \
+            --var="project=${{ secrets.GCP_PROJECT }}" \
+            --var="cluster_location=${{ vars.GCP_CLUSTER_LOCATION }}" \
+            --var="cluster_machine_type=${{ vars.GCP_CLUSTER_MACHINE_TYPE }}" \
+            --var="upstream_machine_type=${{ vars.GCP_UPSTREAM_MACHINE_TYPE }}" \
+            --var="tests_machine_type=${{ vars.GCP_TEST_MACHINE_TYPE }}" \
+            --var-file=main.tfvars \
+            --auto-approve
+
+  destroy-cluster:
+    name: "Destroy ${{ inputs.cloud }} cluster"
+    runs-on: ubuntu-latest
+    needs: benchmark
+    if: always()
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Configure AKS credentials
+        if: ${{ inputs.cloud == 'Azure' }}
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Configure AWS credentials
+        if: ${{ inputs.cloud == 'AWS' }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ vars.AWS_CLUSTER_LOCATION }}
+
+      - name: Authenticate into gcloud
+        if: ${{ inputs.cloud == 'GCP' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Install gcloud CLI
+        if: ${{ inputs.cloud == 'GCP' }}
+        uses: google-github-actions/setup-gcloud@v2.1.0
+
+      - name: Install gcloud k8s auth component
+        if: ${{ inputs.cloud == 'GCP' }}
+        run: gcloud components install gke-gcloud-auth-plugin
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3.1.1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_version: "1.8.2"
+
+      - name: Create Terraform Cloud descriptors
+        run: cp ${{ env.provider }}/terraform.cloud.tf.example ${{ env.provider }}/terraform.cloud.tf
+
+      - name: Copy cluster config
+        run: cp "${{ env.CUSTOM_TESTS_DIR }}/tyk-otel-baseline/cluster.tf" ${{ env.provider }}/main.tfvars
+
+      - name: Destroy AKS cluster
+        if: ${{ inputs.cloud == 'Azure' }}
+        run: |
+          cd aks
+          terraform init
+          terraform destroy \
+            --var="cluster_location=${{ vars.AZURE_CLUSTER_LOCATION }}" \
+            --var="cluster_machine_type=${{ vars.AZURE_CLUSTER_MACHINE_TYPE }}" \
+            --var="upstream_machine_type=${{ vars.AZURE_UPSTREAM_MACHINE_TYPE }}" \
+            --var="tests_machine_type=${{ vars.AZURE_TEST_MACHINE_TYPE }}" \
+            --var-file=main.tfvars \
+            --auto-approve
+
+      - name: Destroy EKS cluster
+        if: ${{ inputs.cloud == 'AWS' }}
+        run: |
+          cd eks
+          terraform init
+          terraform destroy \
+            --var="cluster_location=${{ vars.AWS_CLUSTER_LOCATION }}" \
+            --var="cluster_machine_type=${{ vars.AWS_CLUSTER_MACHINE_TYPE }}" \
+            --var="upstream_machine_type=${{ vars.AWS_UPSTREAM_MACHINE_TYPE }}" \
+            --var="tests_machine_type=${{ vars.AWS_TEST_MACHINE_TYPE }}" \
+            --var-file=main.tfvars \
+            --auto-approve
+
+      - name: Destroy GKE cluster
+        if: ${{ inputs.cloud == 'GCP' }}
+        run: |
+          cd gke
+          terraform init
+          terraform destroy \
+            --var="project=${{ secrets.GCP_PROJECT }}" \
+            --var="cluster_location=${{ vars.GCP_CLUSTER_LOCATION }}" \
+            --var="cluster_machine_type=${{ vars.GCP_CLUSTER_MACHINE_TYPE }}" \
+            --var="upstream_machine_type=${{ vars.GCP_UPSTREAM_MACHINE_TYPE }}" \
+            --var="tests_machine_type=${{ vars.GCP_TEST_MACHINE_TYPE }}" \
+            --var-file=main.tfvars \
+            --auto-approve

--- a/.github/workflows/otel_metrics_benchmark.yml
+++ b/.github/workflows/otel_metrics_benchmark.yml
@@ -42,6 +42,9 @@ jobs:
           - tyk-otel-metrics-runtime
           - tyk-otel-metrics-tracing
           - tyk-otel-metrics-tracing-full
+          - tyk-analytics-database
+          - tyk-analytics-prometheus
+          - tyk-otel-metrics-vs-analytics
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -33,8 +33,10 @@ module "deployments" {
   }
 
   open_telemetry = {
-    enabled        = var.open_telemetry_enabled
-    sampling_ratio = var.open_telemetry_sampling_ratio
+    enabled         = var.open_telemetry_enabled
+    sampling_ratio  = var.open_telemetry_sampling_ratio
+    metrics_enabled = var.open_telemetry_metrics_enabled
+    runtime_metrics = var.open_telemetry_metrics_runtime_metrics
   }
 
   header_injection = {

--- a/deployments/vars.middleware.tf
+++ b/deployments/vars.middleware.tf
@@ -70,6 +70,18 @@ variable "open_telemetry_sampling_ratio" {
   description = "Open Telemetry sampling ration 0 to 1.0 range."
 }
 
+variable "open_telemetry_metrics_enabled" {
+  type        = bool
+  default     = false
+  description = "Enable OpenTelemetry metrics collection on gateway services."
+}
+
+variable "open_telemetry_metrics_runtime_metrics" {
+  type        = bool
+  default     = false
+  description = "Enable Go runtime metrics (goroutines, heap, GC) via OpenTelemetry."
+}
+
 variable "header_injection_req_enabled" {
   type        = bool
   default     = false

--- a/modules/deployments/dependencies/otel-collector.tf
+++ b/modules/deployments/dependencies/otel-collector.tf
@@ -77,6 +77,28 @@ resource "helm_release" "opentelemetry-collector" {
     value = "jaeger"
   }
 
+  # Metrics pipeline — export to logging so metrics are processed
+  # without requiring a full metrics backend (Prometheus/Mimir)
+  set {
+    name  = "config.exporters.logging.verbosity"
+    value = "basic"
+  }
+
+  set {
+    name  = "config.service.pipelines.metrics.receivers[0]"
+    value = "otlp"
+  }
+
+  set {
+    name  = "config.service.pipelines.metrics.processors[0]"
+    value = "batch"
+  }
+
+  set {
+    name  = "config.service.pipelines.metrics.exporters[0]"
+    value = "logging"
+  }
+
   count      = var.open_telemetry.enabled ? 1 : 0
   depends_on = [kubernetes_namespace.dependencies]
 }

--- a/modules/deployments/tyk/main.tf
+++ b/modules/deployments/tyk/main.tf
@@ -494,6 +494,30 @@ resource "helm_release" "tyk" {
     }
   }
 
+  # OTel Metrics
+  set {
+    name  = "tyk-gateway.gateway.extraEnvs[18].name"
+    value = "TYK_GW_OPENTELEMETRY_METRICS_ENABLED"
+  }
+
+  set {
+    name  = "tyk-gateway.gateway.extraEnvs[18].value"
+    type  = "string"
+    value = tostring(var.open_telemetry.metrics_enabled)
+  }
+
+  # OTel Runtime Metrics
+  set {
+    name  = "tyk-gateway.gateway.extraEnvs[19].name"
+    value = "TYK_GW_OPENTELEMETRY_METRICS_RUNTIMEMETRICS"
+  }
+
+  set {
+    name  = "tyk-gateway.gateway.extraEnvs[19].value"
+    type  = "string"
+    value = tostring(var.open_telemetry.runtime_metrics)
+  }
+
   # --- Node placement: choose the correct label key per provider ---
   # GKE: cloud.google.com/gke-nodepool (only when strategy is 'strict')
   dynamic "set" {

--- a/modules/deployments/tyk/vars.middleware.tf
+++ b/modules/deployments/tyk/vars.middleware.tf
@@ -34,8 +34,10 @@ variable "rate_limit" {
 
 variable "open_telemetry" {
   type = object({
-    enabled        = bool
-    sampling_ratio = string
+    enabled         = bool
+    sampling_ratio  = string
+    metrics_enabled = bool
+    runtime_metrics = bool
   })
 }
 

--- a/modules/deployments/vars.middleware.tf
+++ b/modules/deployments/vars.middleware.tf
@@ -34,8 +34,10 @@ variable "auth" {
 
 variable "open_telemetry" {
   type = object({
-    enabled        = bool
-    sampling_ratio = string
+    enabled         = bool
+    sampling_ratio  = string
+    metrics_enabled = bool
+    runtime_metrics = bool
   })
 }
 


### PR DESCRIPTION
Extend the open_telemetry variable chain with metrics_enabled and runtime_metrics fields across all Terraform layers. Add corresponding gateway env vars (TYK_GW_OPENTELEMETRY_METRICS_ENABLED, TYK_GW_OPENTELEMETRY_METRICS_RUNTIMEMETRICS) and create 6 test configurations that isolate the cost of each OTel feature: baseline, tracing-only, metrics-only, metrics+runtime, metrics+tracing, and full. A new workflow orchestrates all 6 on a single cluster sequentially.

[TT-16615]

[TT-16615]: https://tyktech.atlassian.net/browse/TT-16615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ