### PR TITLE
security: harden all GitHub Actions workflows

### DIFF
--- a/.github/workflows/AKS.yml
+++ b/.github/workflows/AKS.yml
@@ -1,27 +1,40 @@
 name: AKS Test
 on:
   pull_request:
-    types: [ closed ]
+    types: [ opened, synchronize, closed ]
 
 concurrency:
   group: "Azure"
 
+permissions:
+  contents: read
+
 jobs:
+  dependency-review:
+    name: "Dependency Review"
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@42304edda365365e0a887cf018d8edc34b960b82
+
   azure:
     name: "AKS Test"
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AKS credentials
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/EKS.yml
+++ b/.github/workflows/EKS.yml
@@ -1,29 +1,42 @@
 name: EKS Test
 on:
   pull_request:
-    types: [ closed ]
+    types: [ opened, synchronize, closed ]
 
 concurrency:
   group: "AWS"
 
+permissions:
+  contents: read
+
 jobs:
+  dependency-review:
+    name: "Dependency Review"
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@42304edda365365e0a887cf018d8edc34b960b82
+
   aws:
     name: "EKS Test"
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ vars.AWS_CLUSTER_LOCATION }}
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/GKE.yml
+++ b/.github/workflows/GKE.yml
@@ -1,33 +1,46 @@
 name: GKE Test
 on:
   pull_request:
-    types: [ closed ]
+    types: [ opened, synchronize, closed ]
 
 concurrency:
   group: "GCP"
 
+permissions:
+  contents: read
+
 jobs:
+  dependency-review:
+    name: "Dependency Review"
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Dependency Review
+        uses: actions/dependency-review-action@42304edda365365e0a887cf018d8edc34b960b82
+
   gcp:
     name: "GKE Test"
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Authenticate into gcloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install gcloud k8s auth component
         run: gcloud components install gke-gcloud-auth-plugin
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/clean-up.yml
+++ b/.github/workflows/clean-up.yml
@@ -18,23 +18,26 @@ env:
 concurrency:
   group: ${{ inputs.cloud }}
 
+permissions:
+  contents: read
+
 jobs:
   destroy:
     name: "Clean up ${{ inputs.cloud }} environment"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AKS credentials
         if: ${{ inputs.cloud == 'Azure' }}
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Configure AWS credentials
         if: ${{ inputs.cloud == 'AWS' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -42,20 +45,20 @@ jobs:
 
       - name: Authenticate into gcloud
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install gcloud k8s auth component
         if: ${{ inputs.cloud == 'GCP' }}
         run: gcloud components install gke-gcloud-auth-plugin
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/clear_terraform_state.yml
+++ b/.github/workflows/clear_terraform_state.yml
@@ -13,6 +13,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   clear_state:
     name: "Clear Terraform Cloud workspace: ${{ inputs.workspace_name }}"
@@ -26,10 +29,10 @@ jobs:
           fi
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/cluster.yml
+++ b/.github/workflows/cluster.yml
@@ -31,23 +31,26 @@ env:
 concurrency:
   group: ${{ inputs.cloud }}
 
+permissions:
+  contents: read
+
 jobs:
   cluster:
     name: "${{ inputs.action }} ${{ inputs.cloud }} cluster"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AKS credentials
         if: ${{ inputs.cloud == 'Azure' }}
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Configure AWS credentials
         if: ${{ inputs.cloud == 'AWS' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -55,20 +58,20 @@ jobs:
 
       - name: Authenticate into gcloud
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install gcloud k8s auth component
         if: ${{ inputs.cloud == 'GCP' }}
         run: gcloud components install gke-gcloud-auth-plugin
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/custom_performance_test.yml
+++ b/.github/workflows/custom_performance_test.yml
@@ -33,23 +33,26 @@ env:
 concurrency:
   group: ${{ inputs.cloud }}
 
+permissions:
+  contents: read
+
 jobs:
   performance_test:
     name: "${{ inputs.cloud }} custom full performance test run"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AKS credentials
         if: ${{ inputs.cloud == 'Azure' }}
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Configure AWS credentials
         if: ${{ inputs.cloud == 'AWS' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -57,20 +60,20 @@ jobs:
 
       - name: Authenticate into gcloud
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install gcloud k8s auth component
         if: ${{ inputs.cloud == 'GCP' }}
         run: gcloud components install gke-gcloud-auth-plugin
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -61,23 +61,26 @@ env:
 concurrency:
   group: ${{ inputs.cloud }}
 
+permissions:
+  contents: read
+
 jobs:
   deployments:
     name: "${{ inputs.action }} ${{ inputs.cloud }} deployments"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AKS credentials
         if: ${{ inputs.cloud == 'Azure' }}
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Configure AWS credentials
         if: ${{ inputs.cloud == 'AWS' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -85,20 +88,20 @@ jobs:
 
       - name: Authenticate into gcloud
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install gcloud k8s auth component
         if: ${{ inputs.cloud == 'GCP' }}
         run: gcloud components install gke-gcloud-auth-plugin
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/full.yml.debug
+++ b/.github/workflows/full.yml.debug
@@ -21,7 +21,7 @@
 
       - name: Upload Debug Logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: tyk-debug-logs
           path: |

--- a/.github/workflows/full_performance_test.yml
+++ b/.github/workflows/full_performance_test.yml
@@ -51,27 +51,31 @@ env:
 concurrency:
   group: ${{ inputs.cloud }}
 
+permissions:
+  contents: read
+
 jobs:
   performance_test:
     name: "${{ inputs.cloud }} full performance run on Tyk ${{ inputs.tyk_version }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install wget
         if: ${{ inputs.tyk_profiler_enabled == true }}
-        run: sudo apt-get update && sudo apt-get install -y wget
+        # NOTE: wget is pre-installed on ubuntu-latest runners; kept for resilience
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends wget
 
       - name: Configure AKS credentials
         if: ${{ inputs.cloud == 'Azure' }}
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Configure AWS credentials
         if: ${{ inputs.cloud == 'AWS' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -80,20 +84,20 @@ jobs:
 
       - name: Authenticate into gcloud
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install gcloud k8s auth component
         if: ${{ inputs.cloud == 'GCP' }}
         run: gcloud components install gke-gcloud-auth-plugin
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"
@@ -385,7 +389,7 @@ jobs:
       - name: Upload Profiles
         if: ${{ inputs.tyk_profiler_enabled == true }}
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.tyk_version }}-profiles
           path: ./profiles

--- a/.github/workflows/terraform_reinit.yml
+++ b/.github/workflows/terraform_reinit.yml
@@ -26,17 +26,20 @@ on:
 env:
   provider: ${{ inputs.cloud == 'Azure' && 'aks' || (inputs.cloud == 'AWS' && 'eks' || 'gke') }}
 
+permissions:
+  contents: read
+
 jobs:
   terraform_reinit:
     name: "Reinitialize ${{ inputs.cloud }} ${{ inputs.component }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AWS credentials
         if: ${{ inputs.cloud == 'AWS' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -44,22 +47,22 @@ jobs:
 
       - name: Configure Azure credentials
         if: ${{ inputs.cloud == 'Azure' }}
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Authenticate into gcloud
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"

--- a/.github/workflows/terraform_unlock.yml
+++ b/.github/workflows/terraform_unlock.yml
@@ -23,6 +23,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   unlock:
     name: Force Unlock Terraform Workspace
@@ -30,10 +33,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 

--- a/.github/workflows/terraform_unlock_all.yml
+++ b/.github/workflows/terraform_unlock_all.yml
@@ -14,6 +14,9 @@ on:
           - all
         default: all
 
+permissions:
+  contents: read
+
 jobs:
   unlock_all:
     name: Force Unlock All Related Workspaces
@@ -21,7 +24,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Unlock All Workspaces
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,23 +41,26 @@ env:
 concurrency:
   group: ${{ inputs.cloud }}
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: "${{ inputs.action }} ${{ inputs.cloud }} tests"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Configure AKS credentials
         if: ${{ inputs.cloud == 'Azure' }}
-        uses: azure/login@v2
+        uses: azure/login@1384c340ab2dda50fed2bee3041d1d87018aa5e8 # v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
       - name: Configure AWS credentials
         if: ${{ inputs.cloud == 'AWS' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -65,20 +68,20 @@ jobs:
 
       - name: Authenticate into gcloud
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
 
       - name: Install gcloud CLI
         if: ${{ inputs.cloud == 'GCP' }}
-        uses: google-github-actions/setup-gcloud@v2.1.0
+        uses: google-github-actions/setup-gcloud@98ddc00a17442e89a24bbf282954a3b65ce6d200 # v2.1.0
 
       - name: Install gcloud k8s auth component
         if: ${{ inputs.cloud == 'GCP' }}
         run: gcloud components install gke-gcloud-auth-plugin
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3.1.1
+        uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
         with:
           cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
           terraform_version: "1.8.2"


### PR DESCRIPTION
## Summary

- **Pin all action `uses:` to SHA digests** across all 14 workflow files, eliminating tag-based references that are vulnerable to supply-chain attacks (tag re-pointing, compromised upstream releases)
- **Add `permissions: contents: read`** (least-privilege GITHUB_TOKEN scope) to every workflow, reducing blast radius of token compromise
- **Add `actions/dependency-review-action` gate** to all 3 PR-triggered workflows (AKS, EKS, GKE) to catch vulnerable/malicious dependency changes before merge

### Actions pinned (tag -> SHA):
| Action | Tag | SHA |
|--------|-----|-----|
| actions/checkout | v4 | `34e11487` |
| actions/upload-artifact | v4 | `ea165f8d` |
| actions/upload-artifact | v3 | `ff15f030` |
| aws-actions/configure-aws-credentials | v4 | `ff717079` |
| azure/login | v2 | `1384c340` |
| google-github-actions/auth | v2 | `c200f369` |
| google-github-actions/setup-gcloud | v2.1.0 | `98ddc00a` |
| hashicorp/setup-terraform | v2 | `633666f6` |
| hashicorp/setup-terraform | v3 | `b9cd54a3` |
| hashicorp/setup-terraform | v3.1.1 | `651471c3` |

### Additional hardening:
- Added `--no-install-recommends` to apt-get install in full_performance_test.yml
- Full rescan confirmed: no curl|bash, no unpinned pip/npm/go install, no unpinned Docker images

## Test plan
- [ ] Verify workflows parse correctly (GitHub will validate YAML on push)
- [ ] Run a workflow_dispatch test on a non-destructive workflow (e.g., terraform_unlock) to confirm pinned actions resolve correctly
- [ ] Open a test PR to confirm dependency-review-action runs on AKS/EKS/GKE workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)