### PR TITLE
Remove unnecessary dependency-review jobs from cloud workflows

### DIFF
--- a/.github/workflows/AKS.yml
+++ b/.github/workflows/AKS.yml
@@ -10,16 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  dependency-review:
-    name: "Dependency Review"
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Dependency Review
-        uses: actions/dependency-review-action@42304edda365365e0a887cf018d8edc34b960b82
-
   azure:
     name: "AKS Test"
     if: github.event.pull_request.merged == true

--- a/.github/workflows/EKS.yml
+++ b/.github/workflows/EKS.yml
@@ -10,16 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  dependency-review:
-    name: "Dependency Review"
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Dependency Review
-        uses: actions/dependency-review-action@42304edda365365e0a887cf018d8edc34b960b82
-
   aws:
     name: "EKS Test"
     if: github.event.pull_request.merged == true

--- a/.github/workflows/GKE.yml
+++ b/.github/workflows/GKE.yml
@@ -10,16 +10,6 @@ permissions:
   contents: read
 
 jobs:
-  dependency-review:
-    name: "Dependency Review"
-    if: github.event.action != 'closed'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Dependency Review
-        uses: actions/dependency-review-action@42304edda365365e0a887cf018d8edc34b960b82
-
   gcp:
     name: "GKE Test"
     if: github.event.pull_request.merged == true


### PR DESCRIPTION
## Summary
- Remove `dependency-review` jobs from GKE.yml, EKS.yml, and AKS.yml workflows
- These repos have no package install/build steps that benefit from dependency review scanning

## Context
The previous hardening PR added dependency-review-action to these workflows, but it's unnecessary here since there are no dependency manifests (go.sum, package-lock.json, etc.) to review. The action would just waste CI minutes.

## Test plan
- [ ] Verify GKE, EKS, AKS workflows still trigger correctly on PR events
- [ ] Verify no remaining references to dependency-review-action

🤖 Generated with [Claude Code](https://claude.com/claude-code)